### PR TITLE
Add circle bounds and more

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { BoundingBox, CollisionObject, QuadTree } from './schema';
-import { containsPoint, createPointKey, doBoundingBoxesIntersect, divideBoundingBox, flattenLists } from './util';
+import { Bound, BoundingBox, CollisionObject, QuadTree } from './schema';
+import { containsPoint, createPointKey, doBoundsIntersect, divideBoundingBox, flattenLists } from './util';
 
 function addToQuadTree(quadTree: QuadTree, object: CollisionObject): boolean {
-    const objectBoundingBox: BoundingBox = object.getBoundingBox();
+    const objectBound: Bound = object.getBounds();
 
     // Let's first check if the point this object occupies is within
     // the bounds of the bucket
-    if (!containsPoint(quadTree.bounds, objectBoundingBox)) {
+    if (!containsPoint(quadTree.bounds, objectBound)) {
         return false;
     }
 
@@ -22,7 +22,7 @@ function addToQuadTree(quadTree: QuadTree, object: CollisionObject): boolean {
     }
 
     // Let's get the data already associated with this bucket
-    const objectPointKey: string = createPointKey(objectBoundingBox);
+    const objectPointKey: string = createPointKey(objectBound);
     const objectPointData: CollisionObject[] = quadTree.data.get(objectPointKey) || [];
 
     // Let's check if the object is already in the bucket
@@ -64,8 +64,8 @@ function addToQuadTree(quadTree: QuadTree, object: CollisionObject): boolean {
 }
 
 function removeFromQuadTree(quadTree: QuadTree, object: CollisionObject): boolean {
-    const objectBoundingBox: BoundingBox = object.getBoundingBox();
-    const objectPointKey: string = createPointKey(objectBoundingBox);
+    const objectBound: Bound = object.getBounds();
+    const objectPointKey: string = createPointKey(objectBound);
     const objectPointData: CollisionObject[] = quadTree.data.get(objectPointKey) || [];
     const objectIndex: number = objectPointData.indexOf(object);
 
@@ -106,10 +106,10 @@ function clearQuadTree(quadTree: QuadTree): void {
     quadTree.quadrants = [];
 }
 
-function queryQuadTree(quadTree: QuadTree, bounds: BoundingBox): CollisionObject[] {
+function queryQuadTree(quadTree: QuadTree, bounds: Bound): CollisionObject[] {
     // Check first if the query bounds intersect with the bounds
     // of the bucket, if it doesn't we can bail immediately with an empty list
-    if (!doBoundingBoxesIntersect(quadTree.bounds, bounds)) {
+    if (!doBoundsIntersect(quadTree.bounds, bounds)) {
         return [];
     }
 
@@ -118,7 +118,7 @@ function queryQuadTree(quadTree: QuadTree, bounds: BoundingBox): CollisionObject
         // Let's iterate over the data in the bucket to see
         // if the objects themselves intersect with the query bounds
         return flattenLists([...quadTree.data.values()])
-            .filter(quadObject => doBoundingBoxesIntersect(quadObject.getBoundingBox(), bounds));
+            .filter(quadObject => doBoundsIntersect(quadObject.getBounds(), bounds));
     }
 
     // Check the current nodes children

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -28,5 +28,5 @@ export interface QuadTree {
     add: (object: CollisionObject) => boolean;
     remove: (object: CollisionObject) => boolean;
     clear: () => void;
-    query: (bounds: BoundingBox) => CollisionObject[];
+    query: (bounds: Bound) => CollisionObject[];
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -8,8 +8,14 @@ export interface BoundingBox extends Point {
     height: number;
 }
 
+export interface Circle extends Point {
+    r: number;
+}
+
+export type Bound = BoundingBox | Circle;
+
 export interface CollisionObject {
-    getBoundingBox: () => BoundingBox;
+    getBounds: () => Bound;
 }
 
 export interface QuadTree {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,24 +1,21 @@
 import { BoundingBox, Point } from './schema';
 
 export function containsPoint(bounds: BoundingBox, point: Point) {
-    return point.x >= bounds.x && 
-           point.x <= bounds.x + bounds.width &&
-           point.y >= bounds.y &&
-           point.y <= bounds.y + bounds.height;
+    return doBoundingBoxesIntersect(bounds, {
+        x: point.x,
+        y: point.y,
+        width: 0,
+        height: 0,
+    });
 }
 
 export function doBoundingBoxesIntersect(box1: BoundingBox, box2: BoundingBox): boolean {
-    // If one rectangle is to the side of other (outside)
-    if (box1.x > box2.x + box2.width || box2.x > box1.x + box1.width) {
-        return false;
-    }
-
-    // If one rectangle is above the other (outside)
-    if (box1.y > box2.y + box2.height || box2.y > box1.y + box1.height) {
-        return false;
-    }
-
-    return true;
+    return (
+        box1.x <= box2.x + box2.width &&
+        box1.x + box1.width >= box2.x &&
+        box1.y <= box2.y + box2.height &&
+        box1.y + box1.height >= box2.y
+    );
 }
 
 export function divideBoundingBox(bounds: BoundingBox): BoundingBox[] {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import { BoundingBox, Point } from './schema';
+import { Bound, BoundingBox, Circle, Point } from './schema';
 
 export function containsPoint(bounds: BoundingBox, point: Point) {
     return doBoundingBoxesIntersect(bounds, {
@@ -9,13 +9,51 @@ export function containsPoint(bounds: BoundingBox, point: Point) {
     });
 }
 
-export function doBoundingBoxesIntersect(box1: BoundingBox, box2: BoundingBox): boolean {
+export function isCircle(bound: Bound): bound is Circle {
+    return (bound as Circle).r !== undefined;
+}
+
+export function doBoundsIntersect(bound1: Bound, bound2: Bound) {
+    const isBound1Circle: boolean = isCircle(bound1);
+    const isBound2Circle: boolean = isCircle(bound2);
+    // They are both circles
+    if (isBound1Circle && isBound2Circle) {
+        return doCirclesIntersect(bound1 as Circle, bound2 as Circle);
+    }
+    // They are both bounding boxes
+    if (!isBound1Circle && !isBound2Circle) {
+        return doBoundingBoxesIntersect(bound1 as BoundingBox, bound2 as BoundingBox);
+    }
+    // One is circle, one is box
+    if (isBound1Circle) {
+        return doCircleBoundingBoxIntersect(bound1 as Circle, bound2 as BoundingBox);
+    }
+    return doCircleBoundingBoxIntersect(bound2 as Circle, bound1 as BoundingBox);
+}
+
+// https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Axis-Aligned_Bounding_Box
+function doBoundingBoxesIntersect(box1: BoundingBox, box2: BoundingBox): boolean {
     return (
         box1.x <= box2.x + box2.width &&
         box1.x + box1.width >= box2.x &&
         box1.y <= box2.y + box2.height &&
         box1.y + box1.height >= box2.y
     );
+}
+
+// https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection#Circle_Collision
+function doCirclesIntersect(circle1: Circle, circle2: Circle): boolean {
+    const dx: number = circle1.x - circle2.x;
+    const dy: number = circle1.y - circle2.y;
+    const distance: number = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2));
+    return distance <= circle1.r + circle2.r;
+}
+
+// https://yal.cc/rectangle-circle-intersection-test/
+function doCircleBoundingBoxIntersect(circle: Circle, box: BoundingBox): boolean {
+    const dx: number = circle.x - Math.max(box.x, Math.min(circle.x, box.x + box.width));
+    const dy: number = circle.y - Math.max(box.y, Math.min(circle.y, box.y + box.height));
+    return Math.pow(dx, 2) + Math.pow(dy, 2) <= Math.pow(circle.r, 2);
 }
 
 export function divideBoundingBox(bounds: BoundingBox): BoundingBox[] {

--- a/test/index.ts
+++ b/test/index.ts
@@ -156,7 +156,7 @@ test('can handle adding 2 objects that occupy the same originating point, capaci
     t.truthy(quadTree.add(object2));
     t.is(quadTree.data.size, 1);
 
-    const objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object1.getBoundingBox())) || [];
+    const objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object1.getBounds())) || [];
     t.is(objectsAtPoint.length, 2);
     t.truthy(objectsAtPoint.includes(object1));
     t.truthy(objectsAtPoint.includes(object2));
@@ -180,7 +180,7 @@ test('can handle adding 2 objects that occupy the same originating point, capaci
     t.truthy(quadTree.add(object2));
     t.is(quadTree.data.size, 1);
 
-    const objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object1.getBoundingBox())) || [];
+    const objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object1.getBounds())) || [];
     t.is(objectsAtPoint.length, 2);
     t.truthy(objectsAtPoint.includes(object1));
     t.truthy(objectsAtPoint.includes(object2));
@@ -351,7 +351,7 @@ test('can query the quad tree with bounds - single quadrant object bounding box 
     quadTree.add(object1);
     quadTree.add(object2);
 
-    const results: CollisionObject[] = quadTree.query(object1.getBoundingBox());
+    const results: CollisionObject[] = quadTree.query(object1.getBounds());
     t.is(results.length, 2);
     t.truthy(results.includes(object1));
     t.truthy(results.includes(object2));
@@ -374,7 +374,7 @@ test('can query the quad tree with bounds - multi quadrant query window', t => {
     quadTree.add(object1);
     quadTree.add(object2);
 
-    const results: CollisionObject[] = quadTree.query(object1.getBoundingBox());
+    const results: CollisionObject[] = quadTree.query(object1.getBounds());
     t.is(results.length, 2);
     t.truthy(results.includes(object1));
     t.truthy(results.includes(object2));
@@ -397,7 +397,7 @@ test('can query the quad tree with bounds - multi level', t => {
     quadTree.add(object1);
     quadTree.add(object2);
 
-    const results: CollisionObject[] = quadTree.query(object1.getBoundingBox());
+    const results: CollisionObject[] = quadTree.query(object1.getBounds());
     t.is(results.length, 2);
     t.truthy(results.includes(object1));
     t.truthy(results.includes(object2));
@@ -413,7 +413,7 @@ test('can query the quad tree with bounds - self bounding box', t => {
     });
     quadTree.add(object);
 
-    const results: CollisionObject[] = quadTree.query(object.getBoundingBox());
+    const results: CollisionObject[] = quadTree.query(object.getBounds());
     t.is(results.length, 1);
     t.truthy(results.includes(object));
 });
@@ -432,7 +432,7 @@ test('can query the quad tree with bounds - self bounding box / multi-object', t
     quadTree.add(object1);
     quadTree.add(object2);
 
-    const results: CollisionObject[] = quadTree.query(object1.getBoundingBox());
+    const results: CollisionObject[] = quadTree.query(object1.getBounds());
     t.is(results.length, 2);
     t.truthy(results.includes(object1));
     t.truthy(results.includes(object2));
@@ -523,7 +523,7 @@ test('can remove object at point with multiple objects', t => {
     quadTree.add(object1);
     quadTree.add(object2);
 
-    let objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object2.getBoundingBox())) || [];
+    let objectsAtPoint: CollisionObject[] = quadTree.data.get(createPointKey(object2.getBounds())) || [];
     t.is(quadTree.data.size, 1);
     t.is(quadTree.quadrants.length, 0);
     t.is(objectsAtPoint.length, 2);
@@ -531,7 +531,7 @@ test('can remove object at point with multiple objects', t => {
     t.truthy(objectsAtPoint.includes(object2));
 
     quadTree.remove(object1);
-    objectsAtPoint = quadTree.data.get(createPointKey(object2.getBoundingBox())) || [];
+    objectsAtPoint = quadTree.data.get(createPointKey(object2.getBounds())) || [];
 
     t.is(quadTree.data.size, 1);
     t.is(quadTree.quadrants.length, 0);
@@ -540,7 +540,7 @@ test('can remove object at point with multiple objects', t => {
     t.truthy(objectsAtPoint.includes(object2));
 
     quadTree.remove(object2);
-    objectsAtPoint = quadTree.data.get(createPointKey(object2.getBoundingBox())) || [];
+    objectsAtPoint = quadTree.data.get(createPointKey(object2.getBounds())) || [];
 
     t.is(quadTree.data.size, 0);
     t.is(quadTree.quadrants.length, 0);
@@ -612,7 +612,7 @@ test('can remove object added to quad tree - collapse subtree higher capacity', 
 });
 
 function quadTreeBucketContains(quadTree: QuadTree, object: CollisionObject): boolean {
-    const objectPointDataSet = quadTree.data.get(createPointKey(object.getBoundingBox()));
+    const objectPointDataSet = quadTree.data.get(createPointKey(object.getBounds()));
     if (objectPointDataSet) {
         return objectPointDataSet.includes(object);
     }

--- a/test/util.ts
+++ b/test/util.ts
@@ -15,7 +15,7 @@ export function createMockQuadTree(capacity?: number): QuadTree {
 
 export function createMockObject(bounds: BoundingBox): CollisionObject {
     return {
-        getBoundingBox() {
+        getBounds() {
             return bounds;
         }
     };


### PR DESCRIPTION
Adds Circle as an accepted Bound.

CollisionObject getBoundingBox() renamed to getBounds(). Returning a Bound object instead of a BoundingBox.

Add collision detection for (Circle, Circle), (Circle, BoundingBox)

Consolidated Circle and BoundingBox as Bound

One aggregate collision detection function doBoundsIntersect() switching processing based off input types.